### PR TITLE
Fix favorite and watchlist schemas

### DIFF
--- a/src/main/java/com/universalmediaserver/tmdbapi/endpoint/account/tv/AccountTvV4Endpoint.java
+++ b/src/main/java/com/universalmediaserver/tmdbapi/endpoint/account/tv/AccountTvV4Endpoint.java
@@ -19,6 +19,7 @@ package com.universalmediaserver.tmdbapi.endpoint.account.tv;
 import com.universalmediaserver.tmdbapi.TMDbClient;
 import com.universalmediaserver.tmdbapi.endpoint.Endpoint;
 import com.universalmediaserver.tmdbapi.schema.tv.TvShortResultsSchema;
+import com.universalmediaserver.tmdbapi.schema.tv.TvSimpleResultsSchema;
 import com.universalmediaserver.tmdbapi.schema.tv.TvTypedResultsSchema;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,11 +74,11 @@ public class AccountTvV4Endpoint extends Endpoint {
 	 *
 	 * @return Favorite TV shows.
 	 */
-	public TvShortResultsSchema getFavorites() {
+	public TvSimpleResultsSchema getFavorites() {
 		Map<String, String> query = new HashMap<>();
 		addQueryNumber(query, QUERY_PAGE, page);
 		addQueryString(query, QUERY_SORT_BY, sortBy);
-		return tmdbClient.get(V4_ACCOUNT_ENDPOINT + accountId + TV_FAVORITES_ENDPOINT, TvShortResultsSchema.class, query);
+		return tmdbClient.get(V4_ACCOUNT_ENDPOINT + accountId + TV_FAVORITES_ENDPOINT, TvSimpleResultsSchema.class, query);
 	}
 
 	/**
@@ -97,11 +98,11 @@ public class AccountTvV4Endpoint extends Endpoint {
 	 *
 	 * @return TV shows Watchlist.
 	 */
-	public TvShortResultsSchema getWatchlist() {
+	public TvSimpleResultsSchema getWatchlist() {
 		Map<String, String> query = new HashMap<>();
 		addQueryNumber(query, QUERY_PAGE, page);
 		addQueryString(query, QUERY_SORT_BY, sortBy);
-		return tmdbClient.get(V4_ACCOUNT_ENDPOINT + accountId + TV_WATCHLIST_ENDPOINT, TvShortResultsSchema.class, query);
+		return tmdbClient.get(V4_ACCOUNT_ENDPOINT + accountId + TV_WATCHLIST_ENDPOINT, TvSimpleResultsSchema.class, query);
 	}
 
 	/**

--- a/src/main/java/com/universalmediaserver/tmdbapi/schema/movie/MovieBaseSchema.java
+++ b/src/main/java/com/universalmediaserver/tmdbapi/schema/movie/MovieBaseSchema.java
@@ -18,6 +18,7 @@ package com.universalmediaserver.tmdbapi.schema.movie;
 
 import com.google.gson.annotations.SerializedName;
 import com.universalmediaserver.tmdbapi.schema.IntegerIdSchema;
+import java.util.List;
 
 /**
  * TMDb Movie Base Schema.
@@ -30,6 +31,8 @@ public class MovieBaseSchema extends IntegerIdSchema {
 	private Boolean adult;
 	@SerializedName("backdrop_path")
 	private String backdropPath;
+	@SerializedName("origin_country")
+	private List<String> originCountry;
 	@SerializedName("original_language")
 	private String originalLanguage;
 	@SerializedName("original_title")
@@ -69,6 +72,10 @@ public class MovieBaseSchema extends IntegerIdSchema {
 
 	public String getOriginalTitle() {
 		return originalTitle;
+	}
+
+	public List<String> getOriginCountry() {
+		return originCountry;
 	}
 
 	public double getPopularity() {
@@ -113,6 +120,10 @@ public class MovieBaseSchema extends IntegerIdSchema {
 
 	public void setOriginalTitle(String value) {
 		this.originalTitle = value;
+	}
+
+	public void setOriginCountry(List<String> value) {
+		this.originCountry = value;
 	}
 
 	public void setOverview(String value) {

--- a/src/test/java/com/universalmediaserver/tmdbapi/endpoint/account/tv/AccountTvV4EndpointTest.java
+++ b/src/test/java/com/universalmediaserver/tmdbapi/endpoint/account/tv/AccountTvV4EndpointTest.java
@@ -18,6 +18,7 @@ package com.universalmediaserver.tmdbapi.endpoint.account.tv;
 
 import com.universalmediaserver.tmdbapi.BaseTestClass;
 import com.universalmediaserver.tmdbapi.schema.tv.TvShortResultsSchema;
+import com.universalmediaserver.tmdbapi.schema.tv.TvSimpleResultsSchema;
 import com.universalmediaserver.tmdbapi.schema.tv.TvTypedResultsSchema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -41,7 +42,7 @@ public class AccountTvV4EndpointTest extends BaseTestClass {
 	@Test
 	public void testGetFavorites() {
 		System.out.println("AccountTvV4Endpoint getFavorites");
-		TvShortResultsSchema result = tmdb.accountV4(getTmdbAccount()).forTv().getFavorites();
+		TvSimpleResultsSchema result = tmdb.accountV4(getTmdbAccount()).forTv().getFavorites();
 		assertParsedObject(result);
 	}
 
@@ -61,7 +62,7 @@ public class AccountTvV4EndpointTest extends BaseTestClass {
 	@Test
 	public void testGetWatchlist() {
 		System.out.println("AccountTvV4Endpoint getWatchlist");
-		TvShortResultsSchema result = tmdb.accountV4(getTmdbAccount()).forTv().getWatchlist();
+		TvSimpleResultsSchema result = tmdb.accountV4(getTmdbAccount()).forTv().getWatchlist();
 		assertParsedObject(result);
 	}
 


### PR DESCRIPTION
Maybe this means you had empty watchlist and favorites lists @SurfaceS, or maybe that `adult` field only comes back sometimes. Anyway this change was needed to make tests pass for me